### PR TITLE
:bug: avoid rewriting external links to MDs

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ function fileToPageBody (filePath) {
  */
 function buildPage (header, body, footer) {
   header = header || ''
-  body = body ? body.replace(/(\.md|\.markdown)"/g, '.html"') : ''
+  body = body ? body.replace(/(href="(?!http[s]*\:).*)(\.md|\.markdown)"/g, '$1.html"') : ''
   footer = footer || ''
 
   return header + body + footer

--- a/test/index.js
+++ b/test/index.js
@@ -8,6 +8,9 @@ var header = '<blink>w00t</blink>\n'
 var footer = '<marquee>THE END</marquee>\n'
 var generatedIndex = '<h1>TESTING!</h1>\n'
 var generatedRewrite = '<p><a href="rewrite.html">rewrite me</a></p>\n'
+var generatedNoRewriteHttps = '<p><a href="https://github.com/ngoldman/sitedown/README.md">but not me!</a></p>\n'
+var generatedNoRewriteHttp = '<p><a href="http://github.com/ngoldman/sitedown/README.md">or me!</a></p>\n'
+var generatedRewriteHttpfooMd = '<p><a href="httpfoo.html">rewrite</a></p>\n'
 
 test('markdown to html', function (t) {
   var file = path.join(__dirname, 'markdown', 'README.md')
@@ -29,6 +32,30 @@ test('rewrite markdown links', function (t) {
   var body = sitedown.fileToPageBody(file)
   var html = sitedown.buildPage('', body, '')
   t.equals(html, generatedRewrite, 'markdown link got rewritten')
+  t.end()
+})
+
+test('rewrite markdown links starting named http', function (t) {
+  var file = path.join(__dirname, 'markdown', 'rewritehttpfoo.md')
+  var body = sitedown.fileToPageBody(file)
+  var html = sitedown.buildPage('', body, '')
+  t.equals(html, generatedRewriteHttpfooMd, 'markdown link httpfoo.md got rewritten')
+  t.end()
+})
+
+test('do not rewrite https links to md', function (t) {
+  var file = path.join(__dirname, 'markdown', 'norewritehttps.md')
+  var body = sitedown.fileToPageBody(file)
+  var html = sitedown.buildPage('', body, '')
+  t.equals(html, generatedNoRewriteHttps, 'https hyperlink did not get rewritten')
+  t.end()
+})
+
+test('do not rewrite http links to md', function (t) {
+  var file = path.join(__dirname, 'markdown', 'norewritehttp.md')
+  var body = sitedown.fileToPageBody(file)
+  var html = sitedown.buildPage('', body, '')
+  t.equals(html, generatedNoRewriteHttp, 'http hyperlink did not get rewritten')
   t.end()
 })
 

--- a/test/markdown/norewritehttp.md
+++ b/test/markdown/norewritehttp.md
@@ -1,0 +1,1 @@
+[or me!](http://github.com/ngoldman/sitedown/README.md)

--- a/test/markdown/norewritehttps.md
+++ b/test/markdown/norewritehttps.md
@@ -1,0 +1,1 @@
+[but not me!](https://github.com/ngoldman/sitedown/README.md)

--- a/test/markdown/rewritehttpfoo.md
+++ b/test/markdown/rewritehttpfoo.md
@@ -1,0 +1,1 @@
+[rewrite](httpfoo.md)


### PR DESCRIPTION
This PR updates the regex to avoid changing hyperlinks that link to an external markdown file. I'm unsure of this is a valid corner case for you, but it makes sense to me.

Link | Change to `.html`?
------------ | -------------
`<a href="rules.md">rules</a>` | :white_check_mark: 
`<a href="https://github.com/blah/foo/rules.md">rules</a>` | :x: 
`<a href="http://github.com/blah/foo/stuff.md">stuff</a>` | :x: 
`<a href="httpisgood.md">http/a>` | :white_check_mark: 

Here is a live view of the regex used:
https://regex101.com/r/aM1wH8/1

BTW, wow you certainly have been busy with this since yesterday! :) Looks great!