### PR TITLE
generate css classes for highlightjs support

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,8 @@ var md = require('markdown-it')({
   linkify: true,
   typographer: true
 })
+md.use(require('markdown-it-highlightjs'))
+
 var encoding = { encoding: 'utf8' }
 
 function noop () {}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "cwp": "^1.0.0",
     "event-stream": "^3.3.1",
     "markdown-it": "^4.3.0",
+    "markdown-it-highlightjs": "^2.0.0",
     "minimist": "^1.1.1",
     "mkdirp": "^0.5.1",
     "readdirp": "^1.3.0"


### PR DESCRIPTION
This PR adds the plugin `markdown-it-highlightjs` to the mix, which just adds some additional CSS classes to code blocks.

With this change, including the highlightjs script + css will make code blocks pretty.

Including these two lines in the header and/or footer will make things pretty (this would need to be done manually by the user in their header/footer):
```html
<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.6/styles/default.min.css">
<script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.6/highlight.min.js"></script>
```

I thought about exposing this as another option, but it seems useful for all (and fairly inert if folks don't care about adding the highlightjs script).

What do you think?